### PR TITLE
Enable NSURLSession configuration by users of analytics-is

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -70,7 +70,7 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.configuration = configuration;
         self.serialQueue = seg_dispatch_queue_create_specific("io.segment.analytics", DISPATCH_QUEUE_SERIAL);
         self.messageQueue = [[NSMutableArray alloc] init];
-        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory];
+        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory configFactory:configuration.configFactory];
 #if TARGET_OS_TV
         self.storage = [[SEGUserDefaultsStorage alloc] initWithDefaults:[NSUserDefaults standardUserDefaults] namespacePrefix:nil crypto:configuration.crypto];
 #else

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -70,7 +70,7 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.configuration = configuration;
         self.serialQueue = seg_dispatch_queue_create_specific("io.segment.analytics", DISPATCH_QUEUE_SERIAL);
         self.messageQueue = [[NSMutableArray alloc] init];
-        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory configFactory:configuration.configFactory];
+        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory sessionConfigFactory:configuration.sessionConfigFactory];
 #if TARGET_OS_TV
         self.storage = [[SEGUserDefaultsStorage alloc] initWithDefaults:[NSUserDefaults standardUserDefaults] namespacePrefix:nil crypto:configuration.crypto];
 #else

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -16,13 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SEGHTTPClient : NSObject
 
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
+@property (nonatomic, strong) SEGSessionConfigFactory configFactory;
 @property (nonatomic, readonly) NSMutableDictionary<NSString *, NSURLSession *> *sessionsByWriteKey;
 @property (nonatomic, readonly) NSURLSession *genericSession;
 
 + (SEGRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory _Nullable)requestFactory;
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory configFactory:(SEGSessionConfigFactory)configFactory;
 
 /**
  * Upload dictionary formatted as per https://segment.com/docs/sources/server/http/#batch.

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -16,14 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SEGHTTPClient : NSObject
 
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
-@property (nonatomic, strong) SEGSessionConfigFactory configFactory;
+@property (nonatomic, strong) SEGSessionConfigFactory sessionConfigFactory;
 @property (nonatomic, readonly) NSMutableDictionary<NSString *, NSURLSession *> *sessionsByWriteKey;
 @property (nonatomic, readonly) NSURLSession *genericSession;
 
 + (SEGRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory configFactory:(SEGSessionConfigFactory)configFactory;
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory sessionConfigFactory:(SEGSessionConfigFactory)sessionConfigFactory;
 
 /**
  * Upload dictionary formatted as per https://segment.com/docs/sources/server/http/#batch.

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -20,7 +20,7 @@
 }
 
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory configFactory:(SEGSessionConfigFactory)configFactory
 {
     if (self = [self init]) {
         if (requestFactory == nil) {
@@ -28,6 +28,7 @@
         } else {
             self.requestFactory = requestFactory;
         }
+        self.configFactory = configFactory;
         _sessionsByWriteKey = [NSMutableDictionary dictionary];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.HTTPAdditionalHeaders = @{ @"Accept-Encoding" : @"gzip" };
@@ -40,13 +41,18 @@
 {
     NSURLSession *session = self.sessionsByWriteKey[writeKey];
     if (!session) {
-        NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-        config.HTTPAdditionalHeaders = @{
-            @"Accept-Encoding" : @"gzip",
-            @"Content-Encoding" : @"gzip",
-            @"Content-Type" : @"application/json",
-            @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
-        };
+        NSURLSessionConfiguration *config;
+        if (self.configFactory != nil) {
+            config = self.configFactory(writeKey);
+        } else {
+            config = [NSURLSessionConfiguration defaultSessionConfiguration];
+            config.HTTPAdditionalHeaders = @{
+                                             @"Accept-Encoding" : @"gzip",
+                                             @"Content-Encoding" : @"gzip",
+                                             @"Content-Type" : @"application/json",
+                                             @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
+                                             };
+        }
         session = [NSURLSession sessionWithConfiguration:config];
         self.sessionsByWriteKey[writeKey] = session;
     }

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -20,7 +20,7 @@
 }
 
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory configFactory:(SEGSessionConfigFactory)configFactory
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory sessionConfigFactory:(SEGSessionConfigFactory)sessionConfigFactory
 {
     if (self = [self init]) {
         if (requestFactory == nil) {
@@ -28,7 +28,7 @@
         } else {
             self.requestFactory = requestFactory;
         }
-        self.configFactory = configFactory;
+        self.sessionConfigFactory = sessionConfigFactory;
         _sessionsByWriteKey = [NSMutableDictionary dictionary];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.HTTPAdditionalHeaders = @{ @"Accept-Encoding" : @"gzip" };
@@ -42,8 +42,8 @@
     NSURLSession *session = self.sessionsByWriteKey[writeKey];
     if (!session) {
         NSURLSessionConfiguration *config;
-        if (self.configFactory != nil) {
-            config = self.configFactory(writeKey);
+        if (self.sessionConfigFactory != nil) {
+            config = self.sessionConfigFactory(writeKey);
         } else {
             config = [NSURLSessionConfiguration defaultSessionConfiguration];
             config.HTTPAdditionalHeaders = @{

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -20,6 +20,7 @@
 @end
 
 typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
+typedef NSURLSessionConfiguration *_Nullable (^SEGSessionConfigFactory)(NSString *_Nonnull);
 
 @protocol SEGIntegrationFactory;
 @protocol SEGCrypto;
@@ -114,6 +115,11 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  * Set a custom request factory.
  */
 @property (nonatomic, strong, nullable) SEGRequestFactory requestFactory;
+
+/**
+ * Set a custom request session config factory
+ */
+@property (nonatomic, strong, nullable) SEGSessionConfigFactory configFactory;
 
 /**
  * Set a custom crypto

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -119,7 +119,7 @@ typedef NSURLSessionConfiguration *_Nullable (^SEGSessionConfigFactory)(NSString
 /**
  * Set a custom request session config factory
  */
-@property (nonatomic, strong, nullable) SEGSessionConfigFactory configFactory;
+@property (nonatomic, strong, nullable) SEGSessionConfigFactory sessionConfigFactory;
 
 /**
  * Set a custom crypto


### PR DESCRIPTION
This adds an optional configFactory in the same pattern as the requestFactory that can be used to configure the NSURLSession used for a particular writeKey. The SEGHTTPClient now takes both a a requestFactory and a configFactory in the init. 